### PR TITLE
fix(workflows): update version of golangci-lint-action

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -22,7 +22,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Run golangci-lint
-        uses: golangci/golangci-lint-action@v2
+        uses: golangci/golangci-lint-action@v6
         with:
           version: latest
           only-new-issues: false

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -16,7 +16,6 @@ linters:
   disable-all: true
   enable:
     - bodyclose
-    - depguard
     - dogsled
     - dupl
     - errcheck

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,6 +1,6 @@
 linters-settings:
   govet:
-    check-shadowing: true
+    shadow: true
   golint:
     min-confidence: 0
   maligned:
@@ -16,7 +16,6 @@ linters:
   disable-all: true
   enable:
     - bodyclose
-    - deadcode
     - depguard
     - dogsled
     - dupl
@@ -25,27 +24,23 @@ linters:
     - gocritic
     - gofmt
     - goimports
-    - golint
+    - revive
     - goprintffuncname
     - gosec
     - gosimple
     - govet
     - ineffassign
-    - interfacer
     - misspell
     - nolintlint
     - rowserrcheck
-    - scopelint
     - staticcheck
-    - structcheck
     - stylecheck
     - typecheck
     - unconvert
     - unparam
     - unused
-    - varcheck
     - whitespace
-    - maligned
+    - exportloopref
 
 service:
   golangci-lint-version: 1.33.x

--- a/pkg/cmd/init/init.go
+++ b/pkg/cmd/init/init.go
@@ -12,7 +12,7 @@ func NewCmdInit() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "init [flags]",
 		Short: "Initialize daje on your system",
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(cmd *cobra.Command, args []string) error { //nolint:all
 			return submitAction()
 		},
 	}


### PR DESCRIPTION
# Description

In the #24 I got errors on ci https://github.com/Schrodinger-Hat/Daje/actions/runs/9514258617/job/26226081863?pr=24 non related to the things I'm adding, we are using the v2 version of https://github.com/golangci/golangci-lint-action and there is the v6 as latest.