### PR TITLE
chore: add maintainers section in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@
     <li><a href="#usage">Usage</a></li>
     <li><a href="#contributing">Contributing</a></li>
     <li><a href="#contact">Contact</a></li>
+    <li><a href="#maintainers">Maintainers</a></li>
   </ol>
 </details>
 
@@ -91,3 +92,25 @@ Project Link: [https://github.com/schroedinger-Hat/daje](https://github.com/schr
 [stars-url]: https://github.com/schroedinger-Hat/daje/stargazers
 [issues-shield]: https://img.shields.io/github/issues/schroedinger-Hat/daje.svg?style=for-the-badge
 [issues-url]: https://github.com/schroedinger-Hat/daje/issues
+
+<!-- MAINTAINERS -->
+
+## Maintainers
+
+<div align="center">
+  <table>
+    <tr>
+      <td align="center">
+        <a href="https://github.com/Wabri">
+          <img src="https://github.com/Wabri.png" width="100px;" alt="Gabriele Puliti"/>
+          <br />
+          <sub>
+            <b>Gabriele Puliti</b>
+          </sub>
+        </a>
+        <br />
+        <span>💻 Maintainer</span>
+      </td>
+    </tr>
+  </table>
+</div>


### PR DESCRIPTION
### 🔗 Linked issue

Connected with issue #28

### ❓ Type of change

- [x] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Add the project maintainers in Readme
<img width="449" alt="image" src="https://github.com/user-attachments/assets/4974ab92-b7f6-444a-9964-f82bac92b103" />

### 📝 Checklist

- [ ] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
